### PR TITLE
Reduce calls to tax rate service

### DIFF
--- a/adjusters/AvataxTaxAdjuster.php
+++ b/adjusters/AvataxTaxAdjuster.php
@@ -11,7 +11,7 @@ class AvataxTaxAdjuster implements Commerce_AdjusterInterface {
 
   public function adjust(Commerce_OrderModel &$order, array $lineItems = []){
 
-    if( $order->shippingAddress !== NULL && sizeof($order->lineItems) > 0)
+    if ($order->shippingAddress !== null && $order->shippingMethod != null && sizeof($order->lineItems) > 0)
     {
       $taxService = new SalesTaxService;
 

--- a/services/AvataxTaxAdjuster_SalesTaxService.php
+++ b/services/AvataxTaxAdjuster_SalesTaxService.php
@@ -495,7 +495,7 @@ class AvataxTaxAdjuster_SalesTaxService extends BaseApplicationComponent
         $shipping = $order->totalShippingCost;
         $discount = $order->totalDiscount;
         $tax = $order->totalTax;
-        $total = $order->totalPrice;
+        $total = floatval($order->totalPrice);
 
         $address1 = $order->shippingAddress->address1;
         $address2 = $order->shippingAddress->address2;


### PR DESCRIPTION
Hey guys, our AvaTax subscription got bumped up to a higher subscription level sooner than expected and after talking to their team, we found out that every 10 calls to the API counts as 1 transaction. Started to look into what might be causing more calls than expected and found a couple things.

First, there are certain cases when updating the order in which Commerce will return different values for `$order->totalPrice`. Sometimes it will return 4 digits, while other times it will return trimmed to only the necessary digits. This resulted in AvaTax creating a new signature and creating a new API call even though there had been no change to the order and a cached tax rate already existed. To work around this, returning the `floatval` of `$order->totalPrice` ensures that AvaTax will always find the correct cached tax rate.

Second, I noticed that the plugin was making an API call once when the address was set, then a second after a shipping method was selected. The majority of states collect tax on shipping charges, so that first call is needless since it doesn't include shipping fees when the tax rate is fetched. I think it would be best to require a shipping method before fetching tax rates to help reduce unnecessary API calls. The only downside I see is that for states that don't collect sales tax on shipping they have to wait one more step in the checkout process before tax is added.

Hope these are useful additions to the code. Not sure if the `$order->totalPrice` behavior holds true in Commerce 2.x, but I think it would be good to add the required shipping method to AvaTax 2.0 as well. Thanks!